### PR TITLE
Make tooltip backgrounds darker and less blue in dark mode

### DIFF
--- a/app/components/stats/RecipeContributionGraph.tsx
+++ b/app/components/stats/RecipeContributionGraph.tsx
@@ -253,7 +253,7 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
                                 tooltipPosition &&
                                 hoveredDay.count > 0 && (
                                     <div
-                                        className="pointer-events-none fixed z-50 rounded-md bg-gray-900 px-3 py-2 text-xs text-white shadow-lg dark:bg-gray-800"
+                                        className="pointer-events-none fixed z-50 rounded-md bg-gray-900 px-3 py-2 text-xs text-white shadow-lg dark:bg-neutral-950"
                                         style={{
                                             left: `${tooltipPosition.x}px`,
                                             top: `${tooltipPosition.y}px`,

--- a/app/components/utils/Tooltip.tsx
+++ b/app/components/utils/Tooltip.tsx
@@ -46,19 +46,19 @@ const Tooltip: React.FC<TooltipProps> = ({
             {children}
             {isVisible && (
                 <div
-                    className={`pointer-events-none absolute z-1 rounded-sm bg-white px-2 py-1 text-xs whitespace-nowrap text-gray-800 opacity-100 shadow-md dark:bg-gray-700 dark:text-white ${positionClasses[position]}`}
+                    className={`pointer-events-none absolute z-1 rounded-sm bg-white px-2 py-1 text-xs whitespace-nowrap text-gray-800 opacity-100 shadow-md dark:bg-neutral-950 dark:text-white ${positionClasses[position]}`}
                     data-testid="tooltip"
                 >
                     {text}
                     <div
                         className={`absolute h-0 w-0 border-4 border-transparent ${
                             position === 'top'
-                                ? `bottom-[-8px] left-1/2 -translate-x-1/2 border-t-white dark:border-t-gray-700`
+                                ? `bottom-[-8px] left-1/2 -translate-x-1/2 border-t-white dark:border-t-neutral-950`
                                 : position === 'right'
-                                  ? `top-1/2 left-[-8px] -translate-y-1/2 border-r-white dark:border-r-gray-700`
+                                  ? `top-1/2 left-[-8px] -translate-y-1/2 border-r-white dark:border-r-neutral-950`
                                   : position === 'bottom'
-                                    ? `top-[-8px] left-1/2 -translate-x-1/2 border-b-white dark:border-b-gray-700`
-                                    : `top-1/2 right-[-8px] -translate-y-1/2 border-l-white dark:border-l-gray-700`
+                                    ? `top-[-8px] left-1/2 -translate-x-1/2 border-b-white dark:border-b-neutral-950`
+                                    : `top-1/2 right-[-8px] -translate-y-1/2 border-l-white dark:border-l-neutral-950`
                         }`}
                     />
                 </div>


### PR DESCRIPTION
The user wanted to make the tooltip background darker and less blue in dark theme. I identified the shared Tooltip component and the custom tooltip in RecipeContributionGraph. I changed their dark mode background from bluish-gray (gray-700/gray-800) to neutral-950, which is almost black and color-neutral. I also updated the tooltip arrow colors to match the new background. Verified with unit tests and a custom styling verification test.

Fixes #739

---
*PR created automatically by Jules for task [13289593492884634997](https://jules.google.com/task/13289593492884634997) started by @jorbush*