### PR TITLE
Refactor RecipeContributionGraph to use shared Tooltip component

### DIFF
--- a/__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx
+++ b/__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx
@@ -64,6 +64,16 @@ vi.mock('@/app/utils/date-utils', () => ({
     },
 }));
 
+// Mock Tooltip component to simplify testing
+vi.mock('@/app/components/utils/Tooltip', () => ({
+    __esModule: true,
+    default: ({ children, text }: { children: React.ReactNode; text: string }) => (
+        <div title={text} data-testid="tooltip-wrapper">
+            {children}
+        </div>
+    ),
+}));
+
 describe('<RecipeContributionGraph />', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -148,15 +158,15 @@ describe('<RecipeContributionGraph />', () => {
 
         render(<RecipeContributionGraph recipes={[recipe]} />);
 
-        // Find a day cell that should have a recipe
-        const dayCells = screen.getAllByTitle(/recipe/i);
-        if (dayCells.length > 0) {
-            const dayCell = dayCells[0];
-            fireEvent.mouseEnter(dayCell);
+        // Find a day cell wrapper (which is our mocked Tooltip)
+        const tooltipWrappers = screen.getAllByTitle(/recipe/i);
+        if (tooltipWrappers.length > 0) {
+            const wrapper = tooltipWrappers[0];
+            fireEvent.mouseEnter(wrapper);
 
-            // Check if tooltip appears (it should show recipe count and date)
-            // The tooltip might not be immediately visible, so we check for the structure
-            expect(dayCell).toBeDefined();
+            // Check if tooltip wrapper is present and has the correct title
+            expect(wrapper).toBeDefined();
+            expect(wrapper.getAttribute('title')).toMatch(/recipe/i);
         }
     });
 
@@ -245,15 +255,14 @@ describe('<RecipeContributionGraph />', () => {
 
         render(<RecipeContributionGraph recipes={[recipe]} />);
 
-        const dayCells = screen.getAllByTitle(/recipe/i);
-        if (dayCells.length > 0) {
-            const dayCell = dayCells[0];
-            fireEvent.mouseEnter(dayCell);
-            fireEvent.mouseLeave(dayCell);
+        const tooltipWrappers = screen.getAllByTitle(/recipe/i);
+        if (tooltipWrappers.length > 0) {
+            const wrapper = tooltipWrappers[0];
+            fireEvent.mouseEnter(wrapper);
+            fireEvent.mouseLeave(wrapper);
 
-            // Tooltip should be hidden (we can't easily test this without more complex queries)
-            // But the component should handle the event without errors
-            expect(dayCell).toBeDefined();
+            // The component should handle the event without errors
+            expect(wrapper).toBeDefined();
         }
     });
 });

--- a/app/components/stats/RecipeContributionGraph.tsx
+++ b/app/components/stats/RecipeContributionGraph.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useTranslation } from 'react-i18next';
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import Container from '@/app/components/utils/Container';
+import Tooltip from '@/app/components/utils/Tooltip';
 import { formatDateLanguage } from '@/app/utils/date-utils';
 
 interface RecipeContributionGraphProps {
@@ -19,11 +20,6 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
     recipes,
 }) => {
     const { t } = useTranslation();
-    const [hoveredDay, setHoveredDay] = useState<DayData | null>(null);
-    const [tooltipPosition, setTooltipPosition] = useState<{
-        x: number;
-        y: number;
-    } | null>(null);
 
     // Generate the last year of days, aligned to weeks starting from Sunday
     const { weeks } = useMemo(() => {
@@ -129,23 +125,6 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
         }
     };
 
-    const handleDayHover = (
-        day: DayData,
-        event: React.MouseEvent<HTMLDivElement>
-    ) => {
-        setHoveredDay(day);
-        const rect = event.currentTarget.getBoundingClientRect();
-        setTooltipPosition({
-            x: rect.left + rect.width / 2,
-            y: rect.top - 10,
-        });
-    };
-
-    const handleDayLeave = () => {
-        setHoveredDay(null);
-        setTooltipPosition(null);
-    };
-
     const formatDate = (date: Date) => {
         return formatDateLanguage(date, 'MMM d, yyyy');
     };
@@ -218,58 +197,50 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
                                                 key={weekIndex}
                                                 className="flex flex-col gap-0.5 sm:gap-1"
                                             >
-                                                {week.map((day, dayIndex) => (
-                                                    <div
-                                                        key={`${weekIndex}-${dayIndex}`}
-                                                        className={`h-2.5 w-2.5 rounded-sm transition-colors sm:h-3 sm:w-3 ${getDayColor(
-                                                            day.level
-                                                        )} ${day.count > 0 ? 'hover:ring-green-450/50 cursor-pointer hover:ring-2' : ''}`}
-                                                        onMouseEnter={(e) =>
-                                                            handleDayHover(
-                                                                day,
-                                                                e
-                                                            )
-                                                        }
-                                                        onMouseLeave={
-                                                            handleDayLeave
-                                                        }
-                                                        title={
-                                                            day.count > 0
-                                                                ? `${formatDate(day.date)}: ${day.count} ${day.count === 1 ? t('recipe') : t('recipes')}`
-                                                                : formatDate(
-                                                                      day.date
-                                                                  )
-                                                        }
-                                                    />
-                                                ))}
+                                                {week.map((day, dayIndex) => {
+                                                    const tooltipText =
+                                                        day.count > 0
+                                                            ? `${day.count} ${
+                                                                  day.count ===
+                                                                  1
+                                                                      ? t(
+                                                                            'recipe'
+                                                                        )
+                                                                      : t(
+                                                                            'recipes'
+                                                                        )
+                                                              } ${t(
+                                                                  'on'
+                                                              )} ${formatDate(
+                                                                  day.date
+                                                              )}`
+                                                            : formatDate(
+                                                                  day.date
+                                                              );
+
+                                                    return (
+                                                        <Tooltip
+                                                            key={`${weekIndex}-${dayIndex}`}
+                                                            text={tooltipText}
+                                                        >
+                                                            <div
+                                                                className={`h-2.5 w-2.5 rounded-sm transition-colors sm:h-3 sm:w-3 ${getDayColor(
+                                                                    day.level
+                                                                )} ${
+                                                                    day.count >
+                                                                    0
+                                                                        ? 'hover:ring-green-450/50 cursor-pointer hover:ring-2'
+                                                                        : ''
+                                                                }`}
+                                                            />
+                                                        </Tooltip>
+                                                    );
+                                                })}
                                             </div>
                                         ))}
                                     </div>
                                 </div>
                             </div>
-
-                            {/* Tooltip */}
-                            {hoveredDay &&
-                                tooltipPosition &&
-                                hoveredDay.count > 0 && (
-                                    <div
-                                        className="pointer-events-none fixed z-50 rounded-md bg-gray-900 px-3 py-2 text-xs text-white shadow-lg dark:bg-neutral-950"
-                                        style={{
-                                            left: `${tooltipPosition.x}px`,
-                                            top: `${tooltipPosition.y}px`,
-                                            transform: 'translate(-50%, -100%)',
-                                        }}
-                                    >
-                                        <div className="font-semibold">
-                                            {hoveredDay.count}{' '}
-                                            {hoveredDay.count === 1
-                                                ? t('recipe')
-                                                : t('recipes')}{' '}
-                                            {t('on')}{' '}
-                                            {formatDate(hoveredDay.date)}
-                                        </div>
-                                    </div>
-                                )}
 
                             {/* Legend */}
                             <div className="mt-4 flex flex-wrap items-center justify-center gap-2 px-2 text-[10px] text-gray-500 sm:gap-4 sm:text-xs dark:text-gray-400">


### PR DESCRIPTION
This change refactors the `RecipeContributionGraph` component to use the project's standard `Tooltip` component instead of its own custom implementation. This improves consistency and reduces code duplication.

Key changes:
- Import and use `Tooltip` from `@/app/components/utils/Tooltip`.
- Remove `hoveredDay` and `tooltipPosition` state from `RecipeContributionGraph`.
- Wrap day cells in the graph with the `Tooltip` component.
- Update `__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx` to reflect the changes.
- Verified the changes with a Playwright script and unit tests.

Fixes #747

---
*PR created automatically by Jules for task [2637087244485676952](https://jules.google.com/task/2637087244485676952) started by @jorbush*