### PR TITLE
Remove redundant title attributes causing double tooltips

### DIFF
--- a/__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx
+++ b/__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx
@@ -149,7 +149,7 @@ describe('<RecipeContributionGraph />', () => {
         render(<RecipeContributionGraph recipes={[recipe]} />);
 
         // Find a day cell that should have a recipe
-        const dayCells = screen.getAllByTitle(/recipe/i);
+        const dayCells = screen.getAllByTestId(/contribution-day-[1-9]/);
         if (dayCells.length > 0) {
             const dayCell = dayCells[0];
             fireEvent.mouseEnter(dayCell);
@@ -245,7 +245,7 @@ describe('<RecipeContributionGraph />', () => {
 
         render(<RecipeContributionGraph recipes={[recipe]} />);
 
-        const dayCells = screen.getAllByTitle(/recipe/i);
+        const dayCells = screen.getAllByTestId(/contribution-day-[1-9]/);
         if (dayCells.length > 0) {
             const dayCell = dayCells[0];
             fireEvent.mouseEnter(dayCell);

--- a/app/components/events/EventCalendar.tsx
+++ b/app/components/events/EventCalendar.tsx
@@ -162,10 +162,7 @@ const EventCalendar: React.FC<EventCalendarProps> = ({
                                             className="cursor-pointer"
                                             prefetch={false}
                                         >
-                                            <div
-                                                className="group border-green-450 relative h-6 w-6 overflow-hidden rounded-full border md:h-8 md:w-8"
-                                                title={event.frontmatter.title}
-                                            >
+                                            <div className="group border-green-450 relative h-6 w-6 overflow-hidden rounded-full border md:h-8 md:w-8">
                                                 <Image
                                                     src={
                                                         event.frontmatter

--- a/app/components/stats/RecipeContributionGraph.tsx
+++ b/app/components/stats/RecipeContributionGraph.tsx
@@ -233,13 +233,7 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
                                                         onMouseLeave={
                                                             handleDayLeave
                                                         }
-                                                        title={
-                                                            day.count > 0
-                                                                ? `${formatDate(day.date)}: ${day.count} ${day.count === 1 ? t('recipe') : t('recipes')}`
-                                                                : formatDate(
-                                                                      day.date
-                                                                  )
-                                                        }
+                                                        data-testid={`contribution-day-${day.count}`}
                                                     />
                                                 ))}
                                             </div>


### PR DESCRIPTION
This change fixes a bug where two tooltips would appear when hovering over events in the calendar or days in the recipe contribution graph. One tooltip was generated by the custom `Tooltip` component, while the other was the browser's native tooltip triggered by the `title` attribute.

Key changes:
- Removed `title` attribute from `app/components/events/EventCalendar.tsx`.
- Removed `title` attribute from `app/components/stats/RecipeContributionGraph.tsx`.
- Added `data-testid` to contribution days in `RecipeContributionGraph.tsx` to maintain testability.
- Updated `__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx` to use the new `data-testid`.

Fixes #743

---
*PR created automatically by Jules for task [3249577363302523501](https://jules.google.com/task/3249577363302523501) started by @jorbush*