### PR TITLE
Add missing "recipes" translation key for Catalan, Spanish, and English

### DIFF
--- a/public/locales/ca/translation.json
+++ b/public/locales/ca/translation.json
@@ -551,6 +551,7 @@
     "name_z_a": "Nom (Z-A)",
     "anonymous": "Anònim",
     "recipe": "Recepta",
+    "recipes": "Receptes",
     "recipes_this_month": "aquest mes",
     "recipes_this_year": "aquest any",
     "likes_per_recipe": "m'agrada/recepta",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -553,6 +553,7 @@
     "name_z_a": "Name (Z-A)",
     "anonymous": "Anonymous",
     "recipe": "Recipe",
+    "recipes": "Recipes",
     "recipes_this_month": "this month",
     "recipes_this_year": "this year",
     "likes_per_recipe": "likes/recipe",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -554,6 +554,7 @@
     "name_z_a": "Nombre (Z-A)",
     "anonymous": "Anónimo",
     "recipe": "Receta",
+    "recipes": "Recetas",
     "recipes_this_month": "este mes",
     "recipes_this_year": "este año",
     "likes_per_recipe": "me gusta/receta",


### PR DESCRIPTION
This change adds the missing "recipes" translation key to the Catalan, Spanish, and English translation files. This was specifically requested for the profile page statistics in Catalan, where the label was appearing untranslated. I also added it to Spanish and English for consistency across the application. Verification was performed using Playwright and unit tests.

Fixes #759

---
*PR created automatically by Jules for task [14497877282668827190](https://jules.google.com/task/14497877282668827190) started by @jorbush*