### PR TITLE
Improve dark theme for quest pages

### DIFF
--- a/app/components/modals/QuestModal.tsx
+++ b/app/components/modals/QuestModal.tsx
@@ -150,7 +150,7 @@ const QuestModal = () => {
                     })}
                     disabled={isLoading}
                     rows={5}
-                    className="w-full rounded-lg border border-gray-300 p-3 text-gray-900 transition focus:border-rose-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                    className="w-full rounded-lg border border-gray-300 p-3 text-gray-900 transition focus:border-rose-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-gray-100"
                     placeholder={
                         t('quest_description_placeholder') ||
                         'Describe the recipe you would like someone to create...'
@@ -176,7 +176,7 @@ const QuestModal = () => {
                         id="status"
                         {...register('status')}
                         disabled={isLoading}
-                        className="w-full rounded-lg border border-gray-300 p-3 text-gray-900 transition focus:border-rose-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                        className="w-full rounded-lg border border-gray-300 p-3 text-gray-900 transition focus:border-rose-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-gray-100"
                         data-cy="quest-status"
                     >
                         <option value="open">{t('open') || 'Open'}</option>

--- a/app/components/quests/QuestDetailSkeleton.tsx
+++ b/app/components/quests/QuestDetailSkeleton.tsx
@@ -5,47 +5,47 @@ const QuestDetailSkeleton = () => {
         <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
             {/* Back button skeleton */}
             <div className="mb-6">
-                <div className="h-10 w-24 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+                <div className="h-10 w-24 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800"></div>
             </div>
 
             {/* Quest Header Skeleton */}
-            <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
                 <div className="mb-4 flex items-center justify-between">
-                    <div className="h-6 w-20 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                    <div className="h-6 w-20 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800"></div>
                     <div className="flex gap-2">
-                        <div className="h-10 w-10 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>
-                        <div className="h-10 w-10 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+                        <div className="h-10 w-10 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800"></div>
+                        <div className="h-10 w-10 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800"></div>
                     </div>
                 </div>
 
-                <div className="mb-4 h-9 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-                <div className="mb-2 h-4 w-full animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-                <div className="mb-6 h-4 w-5/6 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                <div className="mb-4 h-9 w-3/4 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                <div className="mb-2 h-4 w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                <div className="mb-6 h-4 w-5/6 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
 
-                <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-gray-700">
+                <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-neutral-800">
                     <div className="flex items-center gap-3">
-                        <div className="h-10 w-10 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"></div>
+                        <div className="h-10 w-10 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800"></div>
                         <div>
-                            <div className="mb-2 h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-                            <div className="h-3 w-20 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                            <div className="mb-2 h-4 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                            <div className="h-3 w-20 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                         </div>
                     </div>
-                    <div className="h-10 w-32 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+                    <div className="h-10 w-32 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800"></div>
                 </div>
             </div>
 
             {/* Recipe Replies Skeleton */}
             <div>
-                <div className="mb-4 h-8 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                <div className="mb-4 h-8 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                 <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                     {[1, 2, 3, 4, 5].map((i) => (
                         <div
                             key={i}
                             className="animate-pulse"
                         >
-                            <div className="aspect-square w-full rounded-lg bg-gray-200 dark:bg-gray-700"></div>
-                            <div className="mt-2 h-4 w-3/4 rounded bg-gray-200 dark:bg-gray-700"></div>
-                            <div className="mt-2 h-3 w-1/2 rounded bg-gray-200 dark:bg-gray-700"></div>
+                            <div className="aspect-square w-full rounded-lg bg-neutral-200 dark:bg-neutral-800"></div>
+                            <div className="mt-2 h-4 w-3/4 rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                            <div className="mt-2 h-3 w-1/2 rounded bg-neutral-200 dark:bg-neutral-800"></div>
                         </div>
                     ))}
                 </div>

--- a/app/components/quests/QuestsClientSkeleton.tsx
+++ b/app/components/quests/QuestsClientSkeleton.tsx
@@ -7,10 +7,10 @@ const QuestsClientSkeleton = () => {
                 {/* Header Skeleton */}
                 <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                     <div>
-                        <div className="mb-2 h-9 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
-                        <div className="h-5 w-96 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                        <div className="mb-2 h-9 w-48 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                        <div className="h-5 w-96 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                     </div>
-                    <div className="h-12 w-40 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-700"></div>
+                    <div className="h-12 w-40 animate-pulse rounded-lg bg-neutral-200 dark:bg-neutral-800"></div>
                 </div>
 
                 {/* Filters Skeleton */}
@@ -18,7 +18,7 @@ const QuestsClientSkeleton = () => {
                     {[1, 2, 3, 4].map((i) => (
                         <div
                             key={i}
-                            className="h-10 w-24 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700"
+                            className="h-10 w-24 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800"
                         ></div>
                     ))}
                 </div>
@@ -28,32 +28,32 @@ const QuestsClientSkeleton = () => {
                     {[1, 2, 3].map((i) => (
                         <div
                             key={i}
-                            className="overflow-hidden rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+                            className="overflow-hidden rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
                         >
                             {/* Header */}
                             <div className="mb-4 flex items-start justify-between">
                                 <div className="flex-1">
                                     <div className="mb-2 flex items-center gap-2">
-                                        <div className="h-6 w-20 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
+                                        <div className="h-6 w-20 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800"></div>
                                     </div>
-                                    <div className="mb-2 h-7 w-3/4 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                                    <div className="mb-2 h-7 w-3/4 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                                     <div className="space-y-2">
-                                        <div className="h-4 w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
-                                        <div className="h-4 w-5/6 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                                        <div className="h-4 w-full animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                                        <div className="h-4 w-5/6 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                                     </div>
                                 </div>
                             </div>
 
                             {/* Footer */}
-                            <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-gray-700">
+                            <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-neutral-800">
                                 <div className="flex items-center gap-3">
-                                    <div className="h-8 w-8 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
+                                    <div className="h-8 w-8 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800"></div>
                                     <div className="space-y-1">
-                                        <div className="h-4 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
-                                        <div className="h-3 w-20 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                                        <div className="h-4 w-24 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
+                                        <div className="h-3 w-20 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                                     </div>
                                 </div>
-                                <div className="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                                <div className="h-4 w-16 animate-pulse rounded bg-neutral-200 dark:bg-neutral-800"></div>
                             </div>
                         </div>
                     ))}

--- a/app/quests/QuestsClient.tsx
+++ b/app/quests/QuestsClient.tsx
@@ -98,13 +98,13 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
     const getStatusColor = (status: string) => {
         switch (status) {
             case 'open':
-                return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+                return 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200';
             case 'in_progress':
-                return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+                return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200';
             case 'completed':
-                return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+                return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
             default:
-                return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
+                return 'bg-gray-100 text-gray-800 dark:bg-neutral-800 dark:text-neutral-200';
         }
     };
 
@@ -158,7 +158,7 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
                                 className={`flex-shrink-0 cursor-pointer rounded-full px-4 py-2 text-sm font-medium transition ${
                                     filter === status
                                         ? 'bg-rose-500 text-white'
-                                        : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                                        : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700'
                                 }`}
                             >
                                 {t(status) || status.replace('_', ' ')}
@@ -180,7 +180,7 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
 
             {/* Quests Grid */}
             {quests.length === 0 ? (
-                <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-700">
+                <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-neutral-800">
                     <FiCircle className="mx-auto mb-4 h-12 w-12 text-gray-400" />
                     <h3 className="mb-2 text-lg font-medium text-gray-900 dark:text-white">
                         {t('no_quests') || 'No quests found'}
@@ -195,7 +195,7 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
                     {quests.map((quest) => (
                         <div
                             key={quest.id}
-                            className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+                            className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:shadow-md dark:border-neutral-800 dark:bg-neutral-900"
                         >
                             <div className="p-6">
                                 {/* Quest Header */}
@@ -234,7 +234,7 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
                                 </div>
 
                                 {/* Quest Footer */}
-                                <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-gray-700">
+                                <div className="flex items-center justify-between border-t border-gray-200 pt-4 dark:border-neutral-800">
                                     <div className="flex items-center gap-3">
                                         <Avatar
                                             src={quest.user.image}
@@ -265,7 +265,7 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
 
                                 {/* Recipe Replies Preview */}
                                 {quest.recipes.length > 0 && (
-                                    <div className="mt-4 border-t border-gray-200 pt-4 dark:border-gray-700">
+                                    <div className="mt-4 border-t border-gray-200 pt-4 dark:border-neutral-800">
                                         <p className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
                                             {t('recipe_replies') ||
                                                 'Recipe Replies'}
@@ -298,7 +298,7 @@ const QuestsClient: React.FC<QuestsClientProps> = ({
                                                     </div>
                                                 ))}
                                             {quest.recipes.length > 4 && (
-                                                <div className="flex h-20 w-20 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700">
+                                                <div className="flex h-20 w-20 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-neutral-800">
                                                     <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
                                                         +
                                                         {quest.recipes.length -

--- a/app/quests/[questId]/QuestDetailClient.tsx
+++ b/app/quests/[questId]/QuestDetailClient.tsx
@@ -99,13 +99,13 @@ const QuestDetailClient: React.FC<QuestDetailClientProps> = ({
     const getStatusColor = (status: string) => {
         switch (status) {
             case 'open':
-                return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+                return 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200';
             case 'in_progress':
-                return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+                return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200';
             case 'completed':
-                return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+                return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
             default:
-                return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
+                return 'bg-gray-100 text-gray-800 dark:bg-neutral-800 dark:text-neutral-200';
         }
     };
 
@@ -164,7 +164,7 @@ const QuestDetailClient: React.FC<QuestDetailClientProps> = ({
                 </button>
 
                 {/* Quest Header */}
-                <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                <div className="mb-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
                     <div className="mb-4 flex items-center justify-between">
                         <div className="flex items-center gap-2">
                             {getStatusIcon(quest.status)}
@@ -181,7 +181,7 @@ const QuestDetailClient: React.FC<QuestDetailClientProps> = ({
                             <button
                                 onClick={() => share({ title: quest.title })}
                                 aria-label={t('share_quest') || 'Share Quest'}
-                                className="cursor-pointer rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                                className="cursor-pointer rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
                                 data-cy="share-quest"
                             >
                                 <FiShare2 />
@@ -193,7 +193,7 @@ const QuestDetailClient: React.FC<QuestDetailClientProps> = ({
                                         aria-label={
                                             t('edit_quest') || 'Edit Quest'
                                         }
-                                        className="cursor-pointer rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                                        className="cursor-pointer rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition hover:bg-gray-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
                                         data-cy="edit-quest"
                                     >
                                         <FiEdit />
@@ -227,7 +227,7 @@ const QuestDetailClient: React.FC<QuestDetailClientProps> = ({
                         {quest.description}
                     </p>
 
-                    <div className="flex flex-col justify-between gap-5 border-t border-gray-200 pt-4 md:flex-row md:items-center dark:border-gray-700">
+                    <div className="flex flex-col justify-between gap-5 border-t border-gray-200 pt-4 md:flex-row md:items-center dark:border-neutral-800">
                         <div className="flex items-center gap-3">
                             <Avatar
                                 src={quest.user.image}
@@ -269,7 +269,7 @@ const QuestDetailClient: React.FC<QuestDetailClientProps> = ({
                         {quest.recipes.length})
                     </h2>
                     {quest.recipes.length === 0 ? (
-                        <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-gray-700">
+                        <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center dark:border-neutral-800">
                             <p className="text-gray-600 dark:text-gray-400">
                                 {t('no_recipes_yet') ||
                                     'No recipes have been submitted yet'}


### PR DESCRIPTION
The dark theme for quest pages has been improved by transitioning from a blue-tinted gray palette to a deeper, more neutral black palette.

Key changes:
- Updated `QuestsClient`, `QuestDetailClient`, and their skeletons to use `dark:bg-neutral-900` and `dark:border-neutral-800`.
- Modified `QuestModal` to use consistent neutral dark colors for form elements.
- Refined status badge colors in dark mode, specifically using `dark:bg-blue-950` for 'open' quests to reduce excessive blue while maintaining clear status indication.
- Ensured consistent look across the entire quest-related user journey (list, detail, creation/edit modals).

Fixes #764

---
*PR created automatically by Jules for task [15503983903379502699](https://jules.google.com/task/15503983903379502699) started by @jorbush*