### PR TITLE
Localize Blog Card Dates and Improve Locale Handling

### DIFF
--- a/__tests__/repro_bug_v2.test.ts
+++ b/__tests__/repro_bug_v2.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import i18n from 'i18next';
+import { formatDate } from '@/app/utils/date-utils';
+
+describe('date-utils bug reproduction v2', () => {
+    afterEach(() => {
+        i18n.language = 'es';
+    });
+
+    it('should format date in English when language is en-US', () => {
+        i18n.language = 'en-US';
+
+        const testDate = new Date('2024-05-20T12:00:00Z');
+        const result = formatDate(testDate);
+
+        expect(result).toContain('May');
+        expect(result).not.toContain('mayo');
+    });
+
+    it('should format date in Spanish when language is es-ES', () => {
+        i18n.language = 'es-ES';
+
+        const testDate = new Date('2024-05-20T12:00:00Z');
+        const result = formatDate(testDate);
+
+        expect(result).toContain('mayo');
+    });
+});

--- a/app/blog/blogs-client.tsx
+++ b/app/blog/blogs-client.tsx
@@ -11,6 +11,7 @@ import ActionCard from '@/app/components/shared/ActionCard';
 import Pagination from '@/app/components/navigation/Pagination';
 import { CONTACT_EMAIL } from '@/app/utils/constants';
 import { SafeUser } from '@/app/types';
+import { formatDate } from '@/app/utils/date-utils';
 
 interface BlogsClientProps {
     currentUser?: SafeUser | null;
@@ -208,9 +209,9 @@ const BlogsClient: React.FC<BlogsClientProps> = ({
                                                     {t('release', 'Release')}
                                                 </span>
                                                 <span className="text-xs text-neutral-500">
-                                                    {new Date(
+                                                    {formatDate(
                                                         blog.frontmatter.date
-                                                    ).toLocaleDateString()}
+                                                    )}
                                                 </span>
                                             </div>
                                             <h4 className="group-hover:text-primary-600 dark:group-hover:text-primary-400 line-clamp-2 font-semibold text-neutral-800 dark:text-neutral-200">

--- a/app/utils/date-utils.ts
+++ b/app/utils/date-utils.ts
@@ -1,5 +1,6 @@
 import { format, formatDistanceToNow } from 'date-fns';
 import { es, enUS, ca } from 'date-fns/locale';
+import i18n from 'i18next';
 
 type LocaleType = 'es' | 'en' | 'ca';
 
@@ -10,23 +11,20 @@ export const locales = {
 };
 
 /**
- * Safely gets the current locale from i18n, only on client-side
- * Falls back to 'es' for server-side rendering
+ * Safely gets the current locale from i18n.
+ * This works on both client and server as long as i18next is initialized.
  */
 const getCurrentLocale = (): LocaleType => {
-    // Only access i18n on client-side to avoid SSR timeout issues
-    if (typeof window !== 'undefined') {
-        try {
-            // Dynamic import to prevent SSR issues
-            // Use i18next directly as it's safe for SSR and avoids path resolution issues in tests.
-            // Since app/i18n.ts initializes the global i18next instance, this will return the same configured instance.
-            const i18n = require('i18next');
-            return (i18n.language as LocaleType) || 'es';
-        } catch {
-            return 'es';
-        }
-    }
-    // Default to 'es' for server-side rendering
+    const lang = i18n.language || 'es';
+
+    // Extract base language (e.g., 'en' from 'en-US')
+    const baseLang = lang.split('-')[0].toLowerCase();
+
+    // Check if it's a supported locale
+    if (baseLang === 'en') return 'en';
+    if (baseLang === 'ca') return 'ca';
+
+    // Default to 'es'
     return 'es';
 };
 


### PR DESCRIPTION
The blog card dates were previously hardcoded to Spanish or failing to localize correctly when regional locale codes (like 'en-US') were used. This PR centralizes date formatting using a robust utility that extracts base language codes and maps them to supported locales, ensuring consistent localization across the blog page and the rest of the application.

Fixes #789

---
*PR created automatically by Jules for task [11013952236073189525](https://jules.google.com/task/11013952236073189525) started by @jorbush*