### PR TITLE
Remove duplicate native tooltips

### DIFF
--- a/__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx
+++ b/__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx
@@ -149,14 +149,13 @@ describe('<RecipeContributionGraph />', () => {
         render(<RecipeContributionGraph recipes={[recipe]} />);
 
         // Find a day cell that should have a recipe
-        const dayCells = screen.getAllByTitle(/recipe/i);
+        const dayCells = screen.getAllByTestId('contribution-day-1');
         if (dayCells.length > 0) {
             const dayCell = dayCells[0];
             fireEvent.mouseEnter(dayCell);
 
             // Check if tooltip appears (it should show recipe count and date)
-            // The tooltip might not be immediately visible, so we check for the structure
-            expect(dayCell).toBeDefined();
+            expect(screen.getByText(/1 recipe on/)).toBeDefined();
         }
     });
 
@@ -245,15 +244,14 @@ describe('<RecipeContributionGraph />', () => {
 
         render(<RecipeContributionGraph recipes={[recipe]} />);
 
-        const dayCells = screen.getAllByTitle(/recipe/i);
+        const dayCells = screen.getAllByTestId('contribution-day-1');
         if (dayCells.length > 0) {
             const dayCell = dayCells[0];
             fireEvent.mouseEnter(dayCell);
-            fireEvent.mouseLeave(dayCell);
+            expect(screen.queryByText(/1 recipe on/)).not.toBeNull();
 
-            // Tooltip should be hidden (we can't easily test this without more complex queries)
-            // But the component should handle the event without errors
-            expect(dayCell).toBeDefined();
+            fireEvent.mouseLeave(dayCell);
+            expect(screen.queryByText(/1 recipe on/)).toBeNull();
         }
     });
 });

--- a/app/components/events/EventCalendar.tsx
+++ b/app/components/events/EventCalendar.tsx
@@ -162,10 +162,7 @@ const EventCalendar: React.FC<EventCalendarProps> = ({
                                             className="cursor-pointer"
                                             prefetch={false}
                                         >
-                                            <div
-                                                className="group border-green-450 relative h-6 w-6 overflow-hidden rounded-full border md:h-8 md:w-8"
-                                                title={event.frontmatter.title}
-                                            >
+                                            <div className="group border-green-450 relative h-6 w-6 overflow-hidden rounded-full border md:h-8 md:w-8">
                                                 <Image
                                                     src={
                                                         event.frontmatter

--- a/app/components/stats/RecipeContributionGraph.tsx
+++ b/app/components/stats/RecipeContributionGraph.tsx
@@ -221,6 +221,7 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
                                                 {week.map((day, dayIndex) => (
                                                     <div
                                                         key={`${weekIndex}-${dayIndex}`}
+                                                        data-testid={`contribution-day-${day.count}`}
                                                         className={`h-2.5 w-2.5 rounded-sm transition-colors sm:h-3 sm:w-3 ${getDayColor(
                                                             day.level
                                                         )} ${day.count > 0 ? 'hover:ring-green-450/50 cursor-pointer hover:ring-2' : ''}`}
@@ -232,13 +233,6 @@ const RecipeContributionGraph: React.FC<RecipeContributionGraphProps> = ({
                                                         }
                                                         onMouseLeave={
                                                             handleDayLeave
-                                                        }
-                                                        title={
-                                                            day.count > 0
-                                                                ? `${formatDate(day.date)}: ${day.count} ${day.count === 1 ? t('recipe') : t('recipes')}`
-                                                                : formatDate(
-                                                                      day.date
-                                                                  )
                                                         }
                                                     />
                                                 ))}


### PR DESCRIPTION
This change fixes an issue where two tooltips would appear when hovering over items in the Event Calendar and the Recipe Contribution Graph. The duplicate tooltip was caused by the presence of a native HTML `title` attribute on elements that also had custom tooltip implementations.

Key changes:
- In `app/components/events/EventCalendar.tsx`, removed the `title` attribute from the event badge containers.
- In `app/components/stats/RecipeContributionGraph.tsx`, removed the `title` attribute from the day cells and added `data-testid` for testing purposes.
- Updated `__tests__/unit_test/components/stats/RecipeContributionGraph.test.tsx` to reflect these changes and ensure the custom tooltip is still working as expected.

Fixes #743

---
*PR created automatically by Jules for task [12168076039947477670](https://jules.google.com/task/12168076039947477670) started by @jorbush*