### PR TITLE
Update co-cooks dark mode background color

### DIFF
--- a/app/components/modals/recipe-steps/RelatedContentStep.tsx
+++ b/app/components/modals/recipe-steps/RelatedContentStep.tsx
@@ -225,7 +225,7 @@ const RelatedContentStep: React.FC<RelatedContentStepProps> = ({
                             {selectedCoCooks.map((user) => (
                                 <div
                                     key={user.id}
-                                    className="flex items-center gap-2 rounded-full bg-gray-100 py-1 pr-2 pl-1 dark:bg-zinc-800"
+                                    className="flex items-center gap-2 rounded-full bg-gray-100 py-1 pr-2 pl-1 dark:bg-neutral-900"
                                 >
                                     <Avatar
                                         src={user.image}
@@ -252,7 +252,7 @@ const RelatedContentStep: React.FC<RelatedContentStepProps> = ({
                         <h3 className="mb-2 text-sm font-medium text-gray-500 dark:text-zinc-400">
                             {t('selected_quest') || 'Selected Quest'}
                         </h3>
-                        <div className="rounded-lg border border-neutral-300 bg-white p-3 dark:border-neutral-600 dark:bg-zinc-800">
+                        <div className="rounded-lg border border-neutral-300 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900">
                             <div className="flex items-start justify-between">
                                 <div className="flex-1">
                                     <p className="font-medium text-zinc-900 dark:text-zinc-100">
@@ -293,7 +293,7 @@ const RelatedContentStep: React.FC<RelatedContentStepProps> = ({
                                 {selectedLinkedRecipes.map((recipe) => (
                                     <div
                                         key={recipe.id}
-                                        className="flex items-center justify-between rounded-lg border border-neutral-300 bg-white p-2 dark:border-neutral-600 dark:bg-zinc-800"
+                                        className="flex items-center justify-between rounded-lg border border-neutral-300 bg-white p-2 dark:border-neutral-800 dark:bg-neutral-900"
                                     >
                                         <div className="flex items-center gap-2">
                                             <div className="relative h-10 w-10 overflow-hidden rounded-md">

--- a/app/components/recipes/RecipeInfo.tsx
+++ b/app/components/recipes/RecipeInfo.tsx
@@ -217,8 +217,8 @@ const RecipeInfo: React.FC<RecipeInfoProps> = ({
                     </h3>
                     <div className="flex flex-wrap gap-2">
                         {/* Loading skeleton */}
-                        <div className="h-8 w-32 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
-                        <div className="h-8 w-28 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+                        <div className="h-8 w-32 animate-pulse rounded-full bg-gray-200 dark:bg-neutral-800" />
+                        <div className="h-8 w-28 animate-pulse rounded-full bg-gray-200 dark:bg-neutral-800" />
                     </div>
                 </div>
             ) : (
@@ -231,7 +231,7 @@ const RecipeInfo: React.FC<RecipeInfoProps> = ({
                             {coCooks.map((cook) => (
                                 <div
                                     key={cook.id}
-                                    className="flex cursor-pointer items-center gap-2 rounded-full bg-gray-100 px-2 py-1 dark:bg-gray-800"
+                                    className="flex cursor-pointer items-center gap-2 rounded-full bg-gray-100 px-2 py-1 dark:bg-neutral-900"
                                     onClick={() =>
                                         router.push(`/profile/${cook.id}`)
                                     }
@@ -362,8 +362,8 @@ const RecipeInfo: React.FC<RecipeInfoProps> = ({
                         </div>
                         <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                             {/* Loading skeletons */}
-                            <div className="h-64 animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700" />
-                            <div className="hidden h-64 animate-pulse rounded-lg bg-gray-200 sm:block dark:bg-gray-700" />
+                            <div className="h-64 animate-pulse rounded-lg bg-gray-200 dark:bg-neutral-800" />
+                            <div className="hidden h-64 animate-pulse rounded-lg bg-gray-200 sm:block dark:bg-neutral-800" />
                         </div>
                     </div>
                 </>


### PR DESCRIPTION
Updated co-cooks and related content dark mode backgrounds to be darker and more neutral. Used `neutral-900` for main backgrounds and `neutral-800` for borders and loading skeletons, replacing the previous blue-tinted `zinc-800` and `gray-800` colors.

Fixes #809

---
*PR created automatically by Jules for task [16892397162773065994](https://jules.google.com/task/16892397162773065994) started by @jorbush*