### PR TITLE
Add Jorbites v1.0.7 Release Blog Posts

### DIFF
--- a/app/content/blogs/ca/releases/1_0_7.md
+++ b/app/content/blogs/ca/releases/1_0_7.md
@@ -1,0 +1,26 @@
+---
+title: Llançament de Jorbites v1.0.7
+date: 2026-03-31T00:00:00.000Z
+description: >-
+  Aquest llançament introdueix diversos esdeveniments de receptes nous, amplía la varietat de reptes setmanals,
+  afegeix un nou mètode de preparació i inclou importants actualitzacions tècniques i de seguretat.
+user_id: 64b39cb3a7f14b7d4b805788
+---
+
+# 🚀 Jorbites v1.0.7 ja és aquí!
+
+Aquesta versió amplía els nostres horitzons culinaris amb nous esdeveniments temàtics, millora el sistema de reptes setmanals i aporta diversos refinaments tècnics a la plataforma.
+
+## ✨ Què hi ha de nou?
+- ✨ **Nous Esdeveniments Culinaris**: Embarca't en nous viatges gastronòmics amb esdeveniments de receptes de l'Índia, Alemanya, Grècia i Mallorca, a més del nou concurs Silk Feast.
+- ✨ **Actualitzacions d'Esdeveniments 2026**: El Festival de Gelat Casolà i el Dia Internacional de l'Alvocat s'han actualitzat amb noves dates per al 2026.
+- ✨ **Reptes Setmanals Ampliats**: Gaudeix de més varietat en els teus reptes setmanals amb opcions ampliades i una selecció de plantilles millorada.
+- ✨ **Nou Mètode de Preparació**: Ara pots seleccionar "Sense cocció" com a mètode de preparació en crear o editar receptes.
+- ✨ **Actualització de la Pàgina Sobre mi**: S'ha afegit una nova secció de Videojocs amb Paltín Dash a la pàgina Sobre mi.
+- ✨ **Refinaments d'UI**: S'ha millorat el color de fons dels co-cuiners en mode fosc per a una millor visibilitat i consistència.
+- ✨ **Millores de Traducció**: S'han corregit diversos problemes de traducció per assegurar una millor experiència en tots els idiomes compatibles.
+- ✨ **Actualitzacions Tècniques i de Seguretat**: S'han implementat mesures per assegurar dades sensibles i s'han actualitzat les dependències principals, incloent `next`, `rollup` i altres a les seves darreres versions.
+- ✨ **Blog de Llançament v1.0.6**: Inclosa la publicació oficial de llançament per a la versió anterior v1.0.6.
+
+🔗 **Changelog complet:**
+[v1.0.7 a GitHub](https://github.com/jorbush/jorbites/releases/tag/v1.0.7)

--- a/app/content/blogs/ca/releases/1_0_7.md
+++ b/app/content/blogs/ca/releases/1_0_7.md
@@ -2,14 +2,14 @@
 title: Llançament de Jorbites v1.0.7
 date: 2026-03-31T00:00:00.000Z
 description: >-
-  Aquest llançament introdueix diversos esdeveniments de receptes nous, amplía la varietat de reptes setmanals,
+  Aquest llançament introdueix diversos esdeveniments de receptes nous, amplia la varietat de reptes setmanals,
   afegeix un nou mètode de preparació i inclou importants actualitzacions tècniques i de seguretat.
 user_id: 64b39cb3a7f14b7d4b805788
 ---
 
 # 🚀 Jorbites v1.0.7 ja és aquí!
 
-Aquesta versió amplía els nostres horitzons culinaris amb nous esdeveniments temàtics, millora el sistema de reptes setmanals i aporta diversos refinaments tècnics a la plataforma.
+Aquesta versió amplia els nostres horitzons culinaris amb nous esdeveniments temàtics, millora el sistema de reptes setmanals i aporta diversos refinaments tècnics a la plataforma.
 
 ## ✨ Què hi ha de nou?
 - ✨ **Nous Esdeveniments Culinaris**: Embarca't en nous viatges gastronòmics amb esdeveniments de receptes de l'Índia, Alemanya, Grècia i Mallorca, a més del nou concurs Silk Feast.

--- a/app/content/blogs/en/releases/1_0_7.md
+++ b/app/content/blogs/en/releases/1_0_7.md
@@ -1,0 +1,26 @@
+---
+title: Jorbites v1.0.7 Release
+date: 2026-03-31T00:00:00.000Z
+description: >-
+  This release introduces several new recipe events, expands the weekly challenge variety,
+  adds a new preparation method, and includes important security and technical updates.
+user_id: 64b39cb3a7f14b7d4b805788
+---
+
+# 🚀 Jorbites v1.0.7 is here!
+
+This version expands our culinary horizons with new themed events, improves the weekly challenge system, and brings various technical refinements to the platform.
+
+## ✨ What's new
+- ✨ **New Culinary Events**: Embark on new gastronomic journeys with Indian, German, Greek, and Mallorca recipe events, plus the new Silk Feast contest.
+- ✨ **2026 Event Updates**: The Homemade Ice Cream Festival and International Avocado Day have been updated with new dates for 2026.
+- ✨ **Expanded Weekly Challenges**: Enjoy more variety in your weekly challenges with expanded options and improved template selection.
+- ✨ **New Preparation Method**: You can now select "No-cook" as a preparation method when creating or editing recipes.
+- ✨ **About Page Update**: A new Videogames section featuring Paltín Dash has been added to the About page.
+- ✨ **UI Refinements**: Improved the co-cooks background color in dark mode for better visibility and consistency.
+- ✨ **Translation Improvements**: Fixed several translation issues to ensure a better experience across all supported languages.
+- ✨ **Security & Technical Updates**: Implemented measures to secure sensitive data and updated core dependencies including `next`, `rollup`, and others to their latest versions.
+- ✨ **v1.0.6 Release Blog**: Included the official blog post for the previous v1.0.6 release.
+
+🔗 **Full Changelog:**
+[v1.0.7 on GitHub](https://github.com/jorbush/jorbites/releases/tag/v1.0.7)

--- a/app/content/blogs/es/releases/1_0_7.md
+++ b/app/content/blogs/es/releases/1_0_7.md
@@ -1,0 +1,26 @@
+---
+title: Lanzamiento de Jorbites v1.0.7
+date: 2026-03-31T00:00:00.000Z
+description: >-
+  Esta versión introduce varios eventos de recetas nuevos, amplía la variedad de desafíos semanales,
+  añade un nuevo método de preparación e incluye importantes actualizaciones técnicas y de seguridad.
+user_id: 64b39cb3a7f14b7d4b805788
+---
+
+# 🚀 ¡Jorbites v1.0.7 ya está aquí!
+
+Esta versión amplía nuestros horizontes culinarios con nuevos eventos temáticos, mejora el sistema de desafíos semanales y aporta varios refinamientos técnicos a la plataforma.
+
+## ✨ ¿Qué hay de nuevo?
+- ✨ **Nuevos Eventos Culinarios**: Embárcate en nuevos viajes gastronómicos con eventos de recetas de la India, Alemania, Grecia y Mallorca, además del nuevo concurso Silk Feast.
+- ✨ **Actualizaciones de Eventos 2026**: El Festival de Helado Casero y el Día Internacional del Aguacate se han actualizado con nuevas fechas para 2026.
+- ✨ **Desafíos Semanales Ampliados**: Disfruta de más variedad en tus desafíos semanales con opciones ampliadas y una selección de plantillas mejorada.
+- ✨ **Nuevo Método de Preparación**: Ahora puedes seleccionar "Sin cocción" como método de preparación al crear o editar recetas.
+- ✨ **Actualización de la Página Sobre mí**: Se ha añadido una nueva sección de Videojuegos con Paltín Dash a la página Sobre mí.
+- ✨ **Refinamientos de UI**: Se ha mejorado el color de fondo de los co-cocineros en modo oscuro para una mejor visibilidad y consistencia.
+- ✨ **Mejoras de Traducción**: Se han corregido varios problemas de traducción para asegurar una mejor experiencia en todos los idiomas admitidos.
+- ✨ **Actualizaciones Técnicas y de Seguridad**: Se han implementado medidas para asegurar datos sensibles y se han actualizado las dependencias principales, incluyendo `next`, `rollup` y otras a sus últimas versiones.
+- ✨ **Blog de Lanzamiento v1.0.6**: Incluida la publicación oficial de lanzamiento para la versión anterior v1.0.6.
+
+🔗 **Changelog completo:**
+[v1.0.7 en GitHub](https://github.com/jorbush/jorbites/releases/tag/v1.0.7)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jorbites",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jorbites",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@axiomhq/js": "^1.3.1",
         "@axiomhq/logging": "^0.1.7",


### PR DESCRIPTION
This PR adds the official release blog posts for Jorbites v1.0.7 in three languages: English, Spanish, and Catalan. It covers the new culinary events, weekly challenge updates, and various technical refinements included in the release. The version in package.json was also verified to ensure consistency with the release.

Fixes #819

---
*PR created automatically by Jules for task [14201526430781436184](https://jules.google.com/task/14201526430781436184) started by @jorbush*