### PR TITLE
Fix Recurrent Event Notifications

### DIFF
--- a/.github/workflows/event-notification.yml
+++ b/.github/workflows/event-notification.yml
@@ -16,18 +16,20 @@ jobs:
           JORBITES_URL: https://jorbites.com
         run: |
           TODAY=$(date -u +'%Y-%m-%d')
+          TODAY_DAY=$(date -u -d "$TODAY" +%-d)
           IN_3_DAYS=$(date -u -d "$TODAY + 3 days" +'%Y-%m-%d')
-          echo "Checking for events starting on: $TODAY"
-          echo "Checking for events ending on: $IN_3_DAYS"
+          IN_3_DAYS_DAY=$(date -u -d "$IN_3_DAYS" +%-d)
+          echo "Checking for events starting on: $TODAY (Day: $TODAY_DAY)"
+          echo "Checking for events ending on: $IN_3_DAYS (Day: $IN_3_DAYS_DAY)"
 
           # Fetch all events (using 'es' as source of truth)
           response=$(curl -s -f "$JORBITES_URL/api/events?lang=es") || { echo "Failed to fetch events"; exit 1; }
 
-          # Filter events where frontmatter.date starts with TODAY
-          STARTED_EVENTS=$(echo "$response" | jq --arg date "$TODAY" -c '[.[] | select(.frontmatter.date != null) | select(.frontmatter.date | sub("T.*"; "") == $date) | {type: "NEW_EVENT", eventId: .slug, title: .frontmatter.title}]')
+          # Filter events where frontmatter.date starts with TODAY or it is a recurrent event for today
+          STARTED_EVENTS=$(echo "$response" | jq --arg date "$TODAY" --arg day "$TODAY_DAY" -c '[.[] | select((.frontmatter.date != null and (.frontmatter.date | sub("T.*"; "") == $date)) or (.frontmatter.recurrent == true and .frontmatter.dayOfMonth == ($day | tonumber))) | {type: "NEW_EVENT", eventId: .slug, title: .frontmatter.title}]')
 
-          # Filter events where frontmatter.endDate is IN_3_DAYS
-          ENDING_EVENTS=$(echo "$response" | jq --arg date "$IN_3_DAYS" -c '[.[] | select(.frontmatter.endDate != null) | select(.frontmatter.endDate | sub("T.*"; "") == $date) | {type: "EVENT_ENDING_SOON", eventId: .slug, title: .frontmatter.title}]')
+          # Filter events where frontmatter.endDate is IN_3_DAYS or it is a recurrent event ending in 3 days
+          ENDING_EVENTS=$(echo "$response" | jq --arg date "$IN_3_DAYS" --arg day "$IN_3_DAYS_DAY" -c '[.[] | select((.frontmatter.endDate != null and (.frontmatter.endDate | sub("T.*"; "") == $date)) or (.frontmatter.recurrent == true and .frontmatter.dayOfMonth == ($day | tonumber))) | {type: "EVENT_ENDING_SOON", eventId: .slug, title: .frontmatter.title}]')
 
           # Combine events
           ALL_EVENTS=$(jq -n -c --argjson started "$STARTED_EVENTS" --argjson ending "$ENDING_EVENTS" '$started + $ending')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jorbites",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jorbites",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@axiomhq/js": "^1.3.1",
         "@axiomhq/logging": "^0.1.7",


### PR DESCRIPTION
I have updated the `.github/workflows/event-notification.yml` file to include support for recurrent events in the daily notification job. 

The previous logic relied solely on the `date` and `endDate` fields in the event's frontmatter. For recurrent events like the "29 of Gnocchis", which occurs every month on the 29th, these fields are often set to a specific historical date, causing them to be ignored by the cron job in subsequent months.

The updated logic now:
1. Calculates the day of the month for "today" and "three days from now".
2. Uses `jq` to filter events that are marked as `recurrent: true` and have a `dayOfMonth` matching either of those days.
3. Continues to support standard one-off events using the existing `date` and `endDate` checks.

I verified the changes using a test script that simulated the workflow's bash and `jq` environment with various mock scenarios (recurrent events, standard events, and different calendar dates). Pre-existing unit and API tests were also run to ensure no regressions were introduced.

Fixes #821

---
*PR created automatically by Jules for task [12859019020590952872](https://jules.google.com/task/12859019020590952872) started by @jorbush*